### PR TITLE
fix: reduce spacing between FAQ buttons

### DIFF
--- a/src/components/sections/FAQ.tsx
+++ b/src/components/sections/FAQ.tsx
@@ -35,7 +35,7 @@ export const FAQ: React.FC = () => {
             to advanced interdimensional functionality.
           </p>
           
-          <div className="flex justify-center space-x-4">
+          <div className="flex justify-center space-x-3">
             <button className="button-outline whimsy-button" onClick={expandAll}>
               Expand All
             </button>


### PR DESCRIPTION
Fixes spacing around Expand All/Collapse All buttons in FAQ area

## Changes
- Reduced spacing from space-x-4 (32px) to space-x-3 (24px)
- Aligns with design system minimum card spacing standard
- Matches button group patterns used throughout codebase

Closes #3

Generated with [Claude Code](https://claude.ai/code)